### PR TITLE
Implement proper mask reveal

### DIFF
--- a/src/components/IntroCanvas.jsx
+++ b/src/components/IntroCanvas.jsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styles from './IntroCanvas.module.css';
-import gsap from 'gsap';
 
 const FRAME_COUNT = 65;
 const pad = (n) => n.toString().padStart(5, '0');
 
 
 
-export default function IntroCanvas() {
+export default function IntroCanvas({ onFinish }) {
   const canvasRef = useRef(null);
   const logoWrapperRef = useRef(null);
   const [images, setImages] = useState([]);
   const [animationFinished, setAnimationFinished] = useState(false);
   const [hideIntro, setHideIntro] = useState(false);
-  const [maskZoomed, setMaskZoomed] = useState(false); // добавляем новое состояние
+  const [maskActive, setMaskActive] = useState(false);
+  const [maskZoomed, setMaskZoomed] = useState(false);
 
   // Загружаем PNG-секвенцию из /public
   useEffect(() => {
@@ -69,21 +69,25 @@ export default function IntroCanvas() {
     animate();
   }, [images]);
 
-  // Кнопка перехода — маска увеличивается, интро исчезает
+  // Нажатие на кнопку включает маску и запускает её масштабирование
   const handleClick = () => {
-  setMaskZoomed(true); // запускаем анимацию увеличения маски
-  setTimeout(() => {
-    setHideIntro(true); // скрываем интро через 1.4с
-  }, 1400);
-};
+    setMaskActive(true);
+    requestAnimationFrame(() => setMaskZoomed(true));
+    setTimeout(() => {
+      setHideIntro(true);
+      if (onFinish) onFinish();
+    }, 1600);
+  };
 
 
   if (hideIntro) return null;
 
   return (
-    <div className={`${styles.wrapper} ${maskZoomed ? styles.maskZoom : ''}`}>
+    <div
+      className={`${styles.wrapper} ${maskActive ? styles.maskApplied : ''} ${maskZoomed ? styles.maskZoom : ''}`}
+    >
 
-      <div ref={logoWrapperRef} className={`${styles.logoMaskLayer} ${maskZoomed ? styles.maskZoom : ''}`}>
+      <div ref={logoWrapperRef} className={styles.logoMaskLayer}>
 
         <canvas ref={canvasRef} className={styles.canvas} />
         </div>

--- a/src/components/IntroCanvas.module.css
+++ b/src/components/IntroCanvas.module.css
@@ -27,6 +27,7 @@
     z-index: 2;
 }
 
+
 .logoMaskLayer {
     position: absolute;
     top: 50%;
@@ -37,11 +38,11 @@
     transition: transform 1.6s ease-in-out;
     z-index: 10;
 
-    -webkit-mask-image: url('/logoAlpha.png');
+    -webkit-mask-image: url('/logoAnim/logoAnim_00064.png');
     -webkit-mask-repeat: no-repeat;
     -webkit-mask-position: center;
     -webkit-mask-size: contain;
-    mask-image: url('/logoAlpha.png');
+    mask-image: url('/logoAnim/logoAnim_00064.png');
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: contain;
@@ -135,6 +136,18 @@
     transform: translateX(-50%);
     text-align: center;
     z-index: 1;
+}
+
+.maskApplied {
+    -webkit-mask-image: url('/logoAnim/logoAnim_00064.png');
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    -webkit-mask-size: contain;
+    mask-image: url('/logoAnim/logoAnim_00064.png');
+    mask-repeat: no-repeat;
+    mask-position: center;
+    mask-size: contain;
+    transition: -webkit-mask-size 1.6s ease-in-out, mask-size 1.6s ease-in-out;
 }
 
 .maskZoom {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   purge: [],
   darkMode: false, // or 'media' or 'class'
   theme: {


### PR DESCRIPTION
## Summary
- activate logo cutout mask on wrapper with delayed zoom trigger
- fire callback when intro overlay hides
- zoom mask via CSS mask-size transition

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ad01eda3883239d1b93c7abe3a7ac